### PR TITLE
Phs/#23 coc syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,13 @@ default: tests
 travis: tests
 
 compile:
-	coqtop.opt -R src '' -compile Way
+	coqtop.opt -I src/Way -as Way -compile Tactics
+	coqtop.opt -I src/Way -as Way -compile Nat
+	coqtop.opt -I src/Way -as Way -compile List
+	coqtop.opt -I src/Way -as Way -compile ListNat
+	coqtop.opt -I src/Way -as Way -compile Atom
+	coqtop.opt -I src/Way -as Way -compile Term
+	coqtop.opt -I src -compile Way
 
 tests: check-metatheory infrastructure-tests
 
@@ -26,7 +32,7 @@ check-metatheory: compile
 	coqchk.opt -R src '' Way
 
 repl:
-	rlwrap coqtop.opt -R src ''
+	rlwrap -pGREEN coqtop.opt -R src '' -require Way
 
 clean:
 	find src -type f '(' -name '*.glob' -o -name '*.vo' ')' -exec rm '{}' ';'

--- a/Makefile
+++ b/Makefile
@@ -25,5 +25,8 @@ tests: check-metatheory infrastructure-tests
 check-metatheory: compile
 	coqchk.opt -R src '' Way
 
+repl:
+	rlwrap coqtop.opt -R src ''
+
 clean:
 	find src -type f '(' -name '*.glob' -o -name '*.vo' ')' -exec rm '{}' ';'

--- a/provisioning/vagrant
+++ b/provisioning/vagrant
@@ -18,3 +18,6 @@ set -x
 
 . "$PROJECT_DIR/vendor/infrastructure/provisioning/client-vagrant"
 . "$PROJECT_DIR/provisioning/common"
+
+sudo apt-get install -y \
+  rlwrap

--- a/src/Way/Atom.v
+++ b/src/Way/Atom.v
@@ -15,9 +15,28 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 *)
 
-Require Export Way.Tactics.
-Require Export Way.Nat.
-Require Export Way.List.
-Require Export Way.ListNat.
-Require Export Way.Atom.
-Require Export Way.Term.
+Require Import Way.List.
+Require Import Way.ListNat.
+Require Import Way.Nat.
+
+Module Type AtomType.
+
+  Parameter atom : Set.
+
+  Parameter fresh_atom : forall (l : list atom), {a : atom | ~ has a l}.
+
+  Parameter eq_atom_dec : forall (a b : atom), {a = b} + {a <> b}.
+
+End AtomType.
+
+Module AtomImpl : AtomType.
+
+  Definition atom := nat.
+
+  Definition fresh_atom := fresh_nat.
+
+  Definition eq_atom_dec := eq_nat_dec.
+
+End AtomImpl.
+
+Export AtomImpl.

--- a/src/Way/List.v
+++ b/src/Way/List.v
@@ -1,0 +1,184 @@
+(*
+  vim: filetype=coq
+*)
+(*
+Copyright (C) 2016-2017 Philip H. Smith
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+*)
+
+Require Import Way.Tactics.
+
+Open Scope list_scope.
+
+Notation " [ ] " := nil (format "[ ]") : list_scope.
+Notation " [ x ] " := (cons x nil) : list_scope.
+Notation " [ x ; y ; .. ; z ] " := (cons x (cons y .. (cons z nil) ..)) : list_scope.
+
+(* Right fold *)
+Fixpoint fold {A B : Type} (f : A -> B -> B) (b : B) (l : list A) {struct l} : B :=
+  match l with
+  | [] => b
+  | a :: t => f a (fold f b t)
+  end.
+
+Module FoldExamples.
+
+Example plus_over_triple : fold plus 0 [3; 1; 4] = 8.
+Proof.
+  infer.
+Defined.
+
+Example cons_over_triple : fold (@cons nat) nil [3; 1; 4] = [3; 1; 4].
+Proof.
+  infer.
+Defined.
+
+End FoldExamples.
+
+Lemma unfold : forall {A B : Type} (f : A -> B -> B) (b : B) (a : A) (t : list A),
+  fold f b (a :: t) = f a (fold f b t).
+Proof.
+  infer.
+Defined.
+
+Definition has {A : Type} (a : A) (l : list A) : Prop :=
+  fold (fun e acc => e = a \/ acc) False l.
+
+Hint Unfold has : way.
+
+Module HasExamples.
+
+Example a_zero_in_pair : has 0 [2; 7] = (2 = 0 \/ 7 = 0 \/ False).
+Proof.
+  infer.
+Defined.
+
+End HasExamples.
+
+Lemma intro_has_singleton :
+  forall {A : Type} (a b : A), b = a -> has a [b].
+Proof.
+  infer.
+Defined.
+
+Hint Resolve intro_has_singleton : way.
+
+Lemma elim_has_singleton :
+  forall {A : Type} (a b : A), has a [b] -> b = a.
+Proof.
+  infer.
+Defined.
+
+Hint Extern 7 => match goal with
+| [ H : has ?a [?b] |- _ ] => pose proof (elim_has_singleton a b H)
+end : way.
+
+Lemma intro_not_has_singleton :
+  forall {A : Type} (a b : A), b <> a -> ~ has a [b].
+Proof.
+  infer.
+Defined.
+
+Hint Resolve intro_not_has_singleton : way.
+
+Lemma elim_not_has_singleton :
+  forall {A : Type} (a b : A), ~ has a [b] -> b <> a.
+Proof.
+  infer.
+Defined.
+
+Hint Extern 7 => match goal with
+| [ H : ~ has ?a [?b] |- _ ] => pose proof (elim_not_has_singleton a b H)
+end : way.
+
+Lemma intro_has_cons :
+  forall {A : Type} (a b : A) (l : list A), b = a \/ has a l -> has a (b :: l).
+Proof.
+  infer.
+Defined.
+
+Hint Resolve intro_has_cons : way.
+
+Lemma elim_has_cons :
+  forall {A : Type} (a b : A) (l : list A), has a (b :: l) -> b = a \/ has a l.
+Proof.
+  infer.
+Defined.
+
+Hint Extern 7 => match goal with
+| [ H : has ?a (?b :: ?l) |- _ ] => pose proof (elim_has_cons a b l H)
+end : way.
+
+Lemma intro_not_has_cons :
+  forall {A : Type} (a b : A) (l : list A), b <> a /\ ~ has a l -> ~ has a (b :: l).
+Proof.
+  infer.
+Defined.
+
+Hint Resolve intro_not_has_cons : way.
+
+Lemma elim_not_has_cons :
+  forall {A : Type} (a b : A) (l : list A), ~ has a (b :: l) -> b <> a /\ ~ has a l.
+Proof.
+  infer.
+Defined.
+
+Hint Extern 7 => match goal with
+| [ H : ~ has ?a (?b :: ?l) |- _ ] => pose proof (elim_not_has_cons a b l H)
+end : way.
+
+Lemma intro_has_append :
+  forall {A : Type} (a : A) (l m : list A), has a l \/ has a m -> has a (m ++ l).
+Proof.
+  induction m; infer.
+Defined.
+
+Hint Resolve intro_has_append : way.
+
+Lemma elim_has_append :
+  forall {A : Type} (a : A) (l m : list A), has a (m ++ l) -> has a l \/ has a m.
+Proof.
+  induction m; infer.
+Defined.
+
+Hint Extern 7 => match goal with
+| [ H : has ?a (?m ++ ?l) |- _ ] => pose proof (elim_has_append a l m H)
+end : way.
+
+Lemma intro_not_has_append :
+  forall {A : Type} (a : A) (l m : list A), ~ has a l /\ ~ has a m -> ~ has a (l ++ m).
+Proof.
+  infer.
+Defined.
+
+Hint Resolve intro_not_has_append : way.
+
+Lemma elim_not_has_append :
+  forall {A : Type} (a : A) (l m : list A), ~ has a (l ++ m) -> ~ has a l /\ ~ has a m.
+Proof.
+  infer.
+Defined.
+
+Hint Extern 7 => match goal with
+| [ H : ~ has ?a (?l ++ ?m) |- _ ] => pose proof (elim_not_has_append a l m H)
+end : way.
+
+Lemma elim_not_has_append2 :
+  forall {A : Type} (a : A) (l m n : list A),
+  ~ has a (l ++ m ++ n) -> ~ has a l /\ ~ has a m /\ ~ has a n.
+Proof.
+  infer.
+Defined.
+
+Hint Extern 7 => match goal with
+| [ H : ~ has ?a (?l ++ ?m ++ ?n) |- _ ] => pose proof (elim_not_has_append2 a l m n H)
+end : way.

--- a/src/Way/ListNat.v
+++ b/src/Way/ListNat.v
@@ -1,0 +1,43 @@
+(*
+  vim: filetype=coq
+*)
+(*
+Copyright (C) 2016-2017 Philip H. Smith
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+*)
+
+Require Import Way.Tactics.
+
+Require Import Way.List.
+Require Import Way.Nat.
+
+Lemma has_le_fold_max : forall (n : nat) (l : list nat), has n l -> n <= fold max 0 l.
+Proof.
+  intro n;
+  induction l;
+  [ infer
+  | infer from eq_nat_dec le_max_l (le_trans n (fold max 0 l)) le_max_r ].
+Defined.
+
+Lemma fold_max_lt_not_has :
+  forall (n : nat) (l : list nat), fold max 0 l < n -> ~ has n l.
+Proof.
+  intros n l;
+  infer from has_le_fold_max (le_lt_trans n (fold max 0 l)) (lt_irrefl n).
+Defined.
+
+Lemma fresh_nat : forall (l : list nat), {n : nat | ~ has n l}.
+Proof.
+  intro l;
+  exists (S (fold max 0 l));
+  infer from fold_max_lt_not_has.
+Defined.

--- a/src/Way/Nat.v
+++ b/src/Way/Nat.v
@@ -1,0 +1,81 @@
+(*
+  vim: filetype=coq
+*)
+(*
+Copyright (C) 2016-2017 Philip H. Smith
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+*)
+
+Require Import Way.Tactics.
+
+Lemma eq_nat_dec : forall (n m : nat), {n = m} + {n <> m}.
+Proof.
+  induction n as [ | ? IH ];
+  induction m;
+  [ | | | destruct (IH m) ];
+  infer.
+Defined.
+
+Lemma le_trans : forall (n m p : nat), n <= m -> m <= p -> n <= p.
+Proof.
+  induction 2; infer.
+Defined.
+
+Lemma le_0_n : forall (n : nat), 0 <= n.
+Proof.
+  induction n; infer.
+Defined.
+
+Lemma le_n_S : forall (n m : nat), n <= m -> S n <= S m.
+Proof.
+  induction 1; infer.
+Defined.
+
+Lemma le_S_n : forall (n m : nat), S n <= S m -> n <= m.
+Proof.
+  intros n m H;
+  inversion H;
+  infer from (le_trans n (S n) m).
+Defined.
+
+Lemma le_Sn_n : forall n, ~ S n <= n.
+Proof.
+  intros n H;
+  induction n;
+  inversion H;
+  infer from le_S_n.
+Defined.
+
+Lemma lt_irrefl : forall (n : nat), ~ n < n.
+Proof.
+  unfold lt;
+  apply le_Sn_n.
+Defined.
+
+Lemma le_lt_trans : forall (n m p : nat), n <= m -> m < p -> n < p.
+Proof.
+  induction 2; infer from le_n_S.
+Defined.
+
+Lemma le_max_l : forall (n m : nat), n <= max n m.
+Proof.
+  induction n;
+  induction m;
+  infer from le_n_S.
+Defined.
+
+Lemma le_max_r : forall (n m : nat), m <= max n m.
+Proof.
+  induction n;
+  induction m;
+  infer from le_0_n le_n_S.
+Defined.

--- a/src/Way/Tactics.v
+++ b/src/Way/Tactics.v
@@ -1,0 +1,116 @@
+(*
+  vim: filetype=coq
+*)
+(*
+Copyright (C) 2016-2017 Philip H. Smith
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+*)
+
+(* Make a private, static copy of the core hint database. *)
+Create HintDb waycore discriminated.
+
+Hint Unfold
+  CompSpec
+  CompSpecT
+  ge
+  gt
+  lt
+  not
+: waycore.
+
+Hint Resolve
+  (f_equal (A:=nat))
+  (f_equal2 (A1:=nat) (A2:=nat))
+  (f_equal2 mult)
+  BoolSpecF
+  BoolSpecT
+  CompEq
+  CompEqT
+  CompGt
+  CompGtT
+  CompLt
+  CompLtT
+  I
+  O_S
+  conj
+  eq_refl
+  ex_intro
+  ex_intro2
+  exist
+  exist2
+  existT
+  existT2
+  identity_refl
+  inhabits
+  inl
+  inleft
+  inr
+  inright
+  le_S
+  le_n
+  left
+  mult_n_O
+  mult_n_Sm
+  n_Sn
+  not_eq_S
+  or_introl
+  or_intror
+  pair
+  plus_n_O
+  plus_n_Sm
+  right
+: waycore.
+
+Hint Immediate
+  eq_add_S
+  eq_sym
+  identity_sym
+  not_eq_sym
+  not_identity_sym
+: waycore.
+
+Hint Constructors
+  le
+: waycore.
+
+(* A separate hint database for our own hints. *)
+Create HintDb way discriminated.
+
+(* Our central work-horse tactic, in the spirit of Prof. Chlipala's crush. *)
+Hint Extern 5 => simpl in * : way.
+Hint Extern 5 => match goal with
+| [ |- context[match ?I with _ => _ end] ] => destruct I
+end : way.
+
+Hint Extern 6 => subst : way.
+Hint Extern 6 => contradiction : way.
+Hint Extern 6 => f_equal : way.
+Hint Extern 6 => congruence : way.
+Hint Extern 6 => progress intuition idtac : way.
+
+Hint Extern 8 => match goal with
+| [ H : ex _ |- _ ] => destruct H
+| [ _ : context[match ?I with _ => _ end] |- _ ] => destruct I
+
+| [ H : _ _ |- _ ] => inversion_clear H
+| [ H : _ _ _ |- _ ] => inversion_clear H
+| [ H : _ _ _ _ |- _ ] => inversion_clear H
+| [ H : _ _ _ _ _ |- _ ] => inversion_clear H
+| [ H : _ _ _ _ _ _ |- _ ] => inversion_clear H
+end : way.
+
+Hint Extern 9 => symmetry : way.
+
+Tactic Notation "infer" "from" constr_list(lemmas) :=
+  auto 5 using lemmas with nocore waycore way.
+
+Tactic Notation "infer" := infer from.

--- a/src/Way/Term.v
+++ b/src/Way/Term.v
@@ -1,0 +1,302 @@
+(*
+  vim: filetype=coq
+*)
+(*
+Copyright (C) 2016-2017 Philip H. Smith
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+*)
+
+Require Import Way.Tactics.
+
+Require Import Way.List.
+Require Import Way.Nat.
+
+Require Export Way.Atom.
+
+(*
+Preterms are structurally identical to terms, but lack proofs of needed invariants.
+
+The "locally nameless" pattern is used to manage variables.  This means that bound
+variables are given de Bruijn indices instead of names.  This eliminates the need for
+alpha conversion, but opens the possibility that bound variable indices may be invalid
+(that is, may refer to abstractions which do not exist).  "Local closure" is the property
+that all such indices are valid, see below.
+*)
+Inductive preterm : Set :=
+
+(* A named variable in an open term *)
+| free_variable : atom -> preterm
+
+(* A nameless variable (a de Bruijn index over all binders) *)
+| bound_variable : nat -> preterm
+
+(* Introduce a lambda *)
+| abstraction : preterm -> preterm
+
+(* Introduce a dependent product *)
+| product : preterm -> preterm
+
+(* Eliminate an abstraction *)
+| application : preterm -> preterm -> preterm
+
+(* Eliminate a product *)
+| product_application : preterm -> preterm -> preterm
+
+(* The hierarchy of type universes *)
+| type : nat -> preterm.
+
+Module Aliases.
+
+Definition fvar := free_variable.
+Definition bvar := bound_variable.
+Definition abs := abstraction.
+Definition prod := product.
+Definition app := application.
+Definition papp := product_application.
+
+End Aliases.
+
+Module PretermExamples.
+
+Include Aliases.
+
+Example omega :=
+  (app
+    (abs (app (bvar 0) (bvar 0)))
+    (abs (app (bvar 0) (bvar 0)))).
+
+(* It looks strange without its typing annotations, but here it is *)
+Example polymorphic_identity := (prod (abs (bvar 0))).
+
+End PretermExamples.
+
+Module LocalClosure.
+
+(* Replace a bound variable i with replacement u in preterm p *)
+Fixpoint substitute_bound (i : nat) (u p : preterm) : preterm :=
+  match p with
+  | free_variable _ => p
+  | bound_variable b => if eq_nat_dec i b then u else p
+  | abstraction b => (abstraction (substitute_bound (S i) u b))
+  | product b => (product (substitute_bound (S i) u b))
+  | application f a =>
+      application (substitute_bound i u f) (substitute_bound i u a)
+  | product_application f a =>
+      product_application (substitute_bound i u f) (substitute_bound i u a)
+  | type _ => p
+  end.
+
+Module SubstituteBoundExamples.
+
+Include Aliases.
+
+Example fvar_is_unchanged :
+  forall (a b : atom), substitute_bound 0 (fvar a) (fvar b) = (fvar b).
+Proof.
+  infer.
+Defined.
+
+Example bvar_is_substituted :
+  forall (a : atom), substitute_bound 0 (fvar a) (bvar 0) = (fvar a).
+Proof.
+  infer.
+Defined.
+
+Example wrong_bvar_is_unchanged :
+  forall (a : atom), substitute_bound 0 (fvar a) (bvar 1) = (bvar 1).
+Proof.
+  infer.
+Defined.
+
+Example abs_substitutes_incremented_bvar :
+  forall (a : atom), substitute_bound 0 (fvar a) (abs (bvar 1)) = (abs (fvar a)).
+Proof.
+  infer.
+Defined.
+
+Example prod_substitutes_incremented_bvar :
+  forall (a : atom), substitute_bound 0 (fvar a) (prod (bvar 1)) = (prod (fvar a)).
+Proof.
+  infer.
+Defined.
+
+Example app_substitutes_into_subterms :
+  forall (a : atom), substitute_bound 0 (fvar a)
+    (app (bvar 0) (bvar 0)) = (app (fvar a) (fvar a)).
+Proof.
+  infer.
+Defined.
+
+Example papp_substitutes_into_subterms :
+  forall (a : atom), substitute_bound 0 (fvar a)
+    (papp (bvar 0) (bvar 0)) = (papp (fvar a) (fvar a)).
+Proof.
+  infer.
+Defined.
+
+Example type_is_unchanged :
+  forall (a : atom) (n : nat), substitute_bound 0 (fvar a) (type n) = (type n).
+Proof.
+  infer.
+Defined.
+
+End SubstituteBoundExamples.
+
+(*
+A preterm is locally closed if every bound variable refers to some abstraction.
+
+A proof of local closure reflects the shape of its preterm, with two key differences.
+
+First, we transform abstraction bodies before demanding local closure of the result.  The
+transformation is to substitute a "sufficiently fresh" free variable for the new bound
+variable. This bound variable will therefore not appear in the preterm of the required
+subproof.
+
+Second, there is no local closure constructor for bound variables.
+
+If all bound variables properly refer to some abstraction, then by the first point they
+will all be replaced by free variables by the time we consider the proof of their local
+closure.  Any bound variables that remain must be dangling.
+
+By the second point, preterms with such bound variables will be unable to prove local
+closure, due to the lack of a suitable constructor.  On the other hand, preterms without
+dangling bound variables will have no need of one.
+
+"Sufficiently fresh" means exclusion from an arbitrary list of free variables, but think
+"free variables of the abstraction body".  Leaving it unspecified here makes proofs
+somewhat easier later, per the "cofinite induction" pattern.
+*)
+Inductive locally_closed : preterm -> Type :=
+
+| free_variable : forall (a : atom), locally_closed (free_variable a)
+
+| abstraction : forall (stale : list atom) (b : preterm),
+  (forall (a : atom), ~ has a stale ->
+    locally_closed (substitute_bound 0 (free_variable a) b)) ->
+  locally_closed (abstraction b)
+
+| product : forall (stale : list atom) (b : preterm),
+  (forall (a : atom), ~ has a stale ->
+    locally_closed (substitute_bound 0 (free_variable a) b)) ->
+  locally_closed (product b)
+
+| application : forall (p q : preterm), locally_closed p -> locally_closed q ->
+  locally_closed (application p q)
+
+| product_application : forall (p q : preterm), locally_closed p -> locally_closed q ->
+  locally_closed (product_application p q)
+
+| type : forall (n : nat), locally_closed (type n).
+
+Module Examples.
+
+Include Aliases.
+
+Example omega :
+  locally_closed (app (abs (app (bvar 0) (bvar 0))) (abs (app (bvar 0) (bvar 0)))).
+Proof.
+  (* TODO(phs): infer search depth/order *)
+  apply application;
+  infer from application (abstraction []) free_variable.
+Defined.
+
+Example polymorphic_identity : locally_closed (prod (abs (bvar 0))).
+Proof.
+  (* TODO(phs): infer search depth/order *)
+  apply (product []);
+  intros; simpl; destruct (eq_nat_dec 1 0); try congruence;
+  infer from (product []) (abstraction []) free_variable.
+Defined.
+
+Example fvar_is_locally_closed : forall (a : atom), locally_closed (fvar a).
+Proof.
+  apply free_variable.
+Defined.
+
+Example abs_can_be_locally_closed : locally_closed (abs (bvar 0)).
+Proof.
+  infer from (abstraction []) free_variable.
+Defined.
+
+Example abs_can_be_not_locally_closed : notT (locally_closed (abs (bvar 1))).
+Proof.
+  intro H;
+  inversion H as [ | stale ? CFH | | | | ];
+  subst;
+  destruct (fresh_atom stale) as [a Hfresh];
+  pose proof (CFH a Hfresh) as Himpossible;
+  infer.
+Defined.
+
+Example prod_can_be_locally_closed : locally_closed (prod (bvar 0)).
+Proof.
+  infer from (product []) free_variable.
+Defined.
+
+Example prod_can_be_not_locally_closed : notT (locally_closed (prod (bvar 1))).
+Proof.
+  intro H;
+  inversion H as [ | | stale ? CFH | | | ];
+  subst;
+  destruct (fresh_atom stale) as [a Hfresh];
+  pose proof (CFH a Hfresh) as Himpossible;
+  infer.
+Defined.
+
+Example app_can_be_locally_closed :
+  forall (a : atom), locally_closed (app (fvar a) (fvar a)).
+Proof.
+  infer from application free_variable.
+Defined.
+
+Example app_can_be_not_locally_closed : notT (locally_closed (app (bvar 0) (bvar 0))).
+Proof.
+  (* TODO(phs): Explicit unfold should be unnecessary. *)
+  unfold notT;
+  infer from application.
+Defined.
+
+Example papp_can_be_locally_closed :
+  forall (a : atom), locally_closed (papp (fvar a) (fvar a)).
+Proof.
+  infer from product_application free_variable.
+Defined.
+
+Example papp_can_be_not_locally_closed : notT (locally_closed (papp (bvar 0) (bvar 0))).
+Proof.
+  (* TODO(phs): Explicit unfold should be unnecessary. *)
+  unfold notT;
+  infer from product_application.
+Defined.
+
+Example type_is_locally_closed : locally_closed (Term.type 0).
+Proof.
+  infer from type.
+Defined.
+
+End Examples.
+
+End LocalClosure.
+
+Definition locally_closed := LocalClosure.locally_closed.
+
+(* A term is a locally closed preterm. *)
+Definition term := { p : preterm & locally_closed p }.
+
+Module Examples.
+
+Definition preterm_omega := PretermExamples.omega.
+Definition omega_locally_closed := LocalClosure.Examples.omega.
+
+Example omega : term := existT locally_closed preterm_omega omega_locally_closed.
+
+End Examples.


### PR DESCRIPTION
Here is a term datatype for a basic type theory.  There is no typing relation yet (we don't immediately reach for a "pure type theory"), nor equality nor sigma types.  We just have products and stratified universe constants.

Variables are handled in the "locally nameless" style, where free variables are identified as `atom`s and bound variables are de Bruijn indices.  To ensure that bound variables refer to actual binders, the datatype is actually `preterm` instead of `term`, which is reserved for `preterms` that satisfy a well-formedness constraint named `locally_closed`.

Closes #23 