### PR TITLE
The calculus of construction definitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,16 +23,26 @@ compile:
 	coqtop.opt -I src/Way -as Way -compile List
 	coqtop.opt -I src/Way -as Way -compile ListNat
 	coqtop.opt -I src/Way -as Way -compile Atom
+	coqtop.opt -I src/Way -as Way -compile Preterm
+	coqtop.opt -I src/Way -as Way -compile Context
+	coqtop.opt -I src/Way -as Way -compile FreeVariables
+	coqtop.opt -I src/Way -as Way -compile StaleAtoms
+	coqtop.opt -I src/Way -as Way -compile Relation
+	coqtop.opt -I src/Way -as Way -compile Open
 	coqtop.opt -I src/Way -as Way -compile Term
-	coqtop.opt -I src -compile Way
+	coqtop.opt -I src/Way -as Way -compile Beta
+	coqtop.opt -I src/Way -as Way -compile Conversion
+	coqtop.opt -I src/Way -as Way -compile Subtyping
+	coqtop.opt -I src/Way -as Way -compile Typing
+	coqtop.opt -I src/Way -as Way -compile Repl
 
 tests: check-metatheory infrastructure-tests
 
 check-metatheory: compile
-	coqchk.opt -R src '' Way
+	coqchk.opt -R src '' Way.Repl
 
 repl:
-	rlwrap -pGREEN coqtop.opt -R src '' -require Way
+	rlwrap -pGREEN coqtop.opt -R src '' -require Repl
 
 clean:
 	find src -type f '(' -name '*.glob' -o -name '*.vo' ')' -exec rm '{}' ';'

--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@
 # Metatheory
 Formal Specification
 
+## Bibliography
+
+* Aydemir, Chargue ́raud, Pierce et al. Engineering Formal Metatheory.  POPL, 2008.
+
+* Bruno Barras and Benjamin Werner. Coq in coq. Available from
+  http://pauillac.inria.fr/~barras/coq_work-eng.html, 1997.
+
+* TODO(phs): cic, paulin-mohring
+
 ## License
 
 Copyright (C) 2016-2017 Philip H. Smith

--- a/src/Way/Atom.v
+++ b/src/Way/Atom.v
@@ -15,9 +15,11 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 *)
 
-Require Import Way.List.
 Require Import Way.ListNat.
 Require Import Way.Nat.
+
+(* Publish notation to clients. *)
+Require Export Way.List.
 
 Module Type AtomType.
 
@@ -40,3 +42,9 @@ Module AtomImpl : AtomType.
 End AtomImpl.
 
 Export AtomImpl.
+
+(* Syntactic sugar for cofinite quantification. *)
+Notation "'fresh' ( a : l ) , P" :=
+  (forall (a : atom), ~ has a l -> P) (at level 67, a at level 99) : way_scope.
+
+Open Scope way_scope.

--- a/src/Way/Beta.v
+++ b/src/Way/Beta.v
@@ -1,0 +1,198 @@
+(*
+  vim: filetype=coq
+*)
+(*
+Copyright (C) 2016-2017 Philip H. Smith
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+*)
+
+Require Import Way.StaleAtoms.
+Require Import Way.Tactics.
+
+Require Import Way.Open.
+Require Import Way.Preterm.
+Require Import Way.Relation.
+Require Import Way.Term.
+
+(* Small-step beta reduction.
+
+Beta reduction eliminates application-abstraction pairs, called beta redexes.  Beta
+reduction is "full": to find redexes beta reduction looks within type annotations and
+abstraction bodies, as well as applications.  In other words, beta redexes appearing in
+either side of applications, abstractions and products may be reduced.
+
+The possibility of computation within abstractions creates non-determinism, but see the
+Church-Rosser property. It shows that no race conditions are present: all evaluation paths
+eventually lead to the same term.
+*)
+Inductive beta : relation :=
+
+(* Applications of abstractions beta reduce to opening the body with the argument.
+
+The function must be a locally closed abstraction and the argument must be locally closed.
+The equation involving open is required to allow proof search to match the head.
+*)
+| redex :
+  forall (T u : preterm), term (Preterm.abstraction T u) ->
+  forall (t : preterm), term t ->
+  forall (v : preterm), v = open 0 t u ->
+  beta (Preterm.application (Preterm.abstraction T u) t) v
+
+(* Beta reduction descends into the function position of applications. *)
+| application_function :
+  forall (u : preterm), term u ->
+  forall (t v : preterm), beta t v ->
+  beta (Preterm.application t u) (Preterm.application v u)
+
+(* Beta reduction descends into the argument position of applications. *)
+| application_argument :
+  forall (t : preterm), term t ->
+  forall (u v : preterm), beta u v ->
+  beta (Preterm.application t u) (Preterm.application t v)
+
+(* Beta reduction descends into the annotation position of abstractions. *)
+| abstraction_annotation :
+  forall (l : list atom) (u : preterm), (fresh (a : l), term (open_free a u)) ->
+  forall (t v : preterm), beta t v ->
+  beta (Preterm.abstraction t u) (Preterm.abstraction v u)
+
+(* Beta reduction descends into the body position of abstractions after opening. *)
+| abstraction_body :
+  forall (l : list atom) (t : preterm), term t ->
+  forall (u v : preterm), (fresh (a : l), beta (open_free a u) (open_free a v)) ->
+  beta (Preterm.abstraction t u) (Preterm.abstraction t v)
+
+(* Beta reduction descends into the domain position of products. *)
+| product_domain :
+  forall (l : list atom) (u : preterm), (fresh (a : l), term (open_free a u)) ->
+  forall (t v : preterm), beta t v ->
+  beta (Preterm.product t u) (Preterm.product v u)
+
+(* Beta reduction descends into the codomain position of products after opening. *)
+| product_codomain :
+  forall (l : list atom) (t : preterm), term t ->
+  forall (u v : preterm), (fresh (a : l), beta (open_free a u) (open_free a v)) ->
+  beta (Preterm.product t u) (Preterm.product t v).
+
+Hint Resolve redex application_function application_argument : way.
+
+Hint Extern 7 (beta (Preterm.abstraction _ _) (Preterm.abstraction _ _)) =>
+  let stale := stale_atoms in
+  match goal with
+  | [ |- beta (Preterm.abstraction ?t ?u) (Preterm.abstraction ?v ?u) ] =>
+    apply (Beta.abstraction_annotation stale)
+  | [ |- beta (Preterm.abstraction ?t ?u) (Preterm.abstraction ?t ?v) ] =>
+    apply (Beta.abstraction_body stale)
+  end : way.
+
+Hint Extern 7 (beta (Preterm.product _ _) (Preterm.product _ _)) =>
+  let stale := stale_atoms in
+  match goal with
+  | [ |- beta (Preterm.product ?t ?u) (Preterm.product ?v ?u) ] =>
+    apply (Beta.product_domain stale)
+  | [ |- beta (Preterm.product ?t ?u) (Preterm.product ?t ?v) ] =>
+    apply (Beta.product_codomain stale)
+  end : way.
+
+(* TODO(phs): Inversion showing beta implies term(?) *)
+(* TODO(phs): Or just demand term from all relations *)
+
+Module Examples.
+
+Import Aliases.
+
+Example omega : beta Preterm.Examples.omega Preterm.Examples.omega.
+Proof.
+  unfold Preterm.Examples.omega; infer.
+Defined.
+
+Example beta_reduction_eliminates_redex :
+  beta
+    (app (abs (type 1) (bvar 0)) (type 0))
+    (type 0).
+Proof.
+  infer.
+Defined.
+
+Example beta_reduction_enters_application_function :
+  beta
+    (app
+      (app (abs (type 2) (bvar 0)) (abs (type 1) (bvar 0)))
+      (type 0))
+    (app
+      (abs (type 1) (bvar 0))
+      (type 0)).
+Proof.
+  infer.
+Defined.
+
+Example beta_reduction_enters_application_argument :
+  beta
+    (app
+      (abs (type 1) (bvar 0))
+      (app (abs (type 1) (bvar 0)) (type 0)))
+    (app
+      (abs (type 1) (bvar 0))
+      (type 0)).
+Proof.
+  infer.
+Defined.
+
+Example beta_reduction_enters_abstraction_annotation :
+  beta
+    (abs
+      (app (abs (type 2) (bvar 0)) (type 1))
+      (type 0))
+    (abs
+      (type 1)
+      (type 0)).
+Proof.
+  infer.
+Defined.
+
+Example beta_reduction_enters_abstraction_body :
+  beta
+    (abs
+      (type 1)
+      (app (abs (type 1) (bvar 0)) (type 0)))
+    (abs
+      (type 1)
+      (type 0)).
+Proof.
+  infer.
+Defined.
+
+Example beta_reduction_enters_product_domain :
+  beta
+    (prod
+      (app (abs (type 1) (bvar 0)) (type 0))
+      (type 0))
+    (prod
+      (type 0)
+      (type 0)).
+Proof.
+  infer.
+Defined.
+
+Example beta_reduction_enters_product_codomain :
+  beta
+    (prod
+      (type 0)
+      (app (abs (type 1) (bvar 0)) (type 0)))
+    (prod
+      (type 0)
+      (type 0)).
+Proof.
+  infer.
+Defined.
+
+End Examples.

--- a/src/Way/Context.v
+++ b/src/Way/Context.v
@@ -1,0 +1,38 @@
+(*
+  vim: filetype=coq
+*)
+(*
+Copyright (C) 2016-2017 Philip H. Smith
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+*)
+
+Require Import Way.Tactics.
+
+Require Import Way.Atom.
+Require Import Way.List.
+Require Import Way.Preterm.
+
+(* Contexts are lists of atom-preterm pairs. *)
+Definition context := list (atom * preterm)%type.
+
+(* The atoms defined by a context. *)
+Function domain (c : context) : list atom := map (@fst atom preterm) c.
+
+Module DomainExamples.
+
+Example triple :
+  forall (a b c : atom) (T U V : preterm), domain [(a, T); (b, U); (c, V)] = [a; b; c].
+Proof.
+  infer.
+Defined.
+
+End DomainExamples.

--- a/src/Way/Conversion.v
+++ b/src/Way/Conversion.v
@@ -1,0 +1,63 @@
+(*
+  vim: filetype=coq
+*)
+(*
+Copyright (C) 2016-2017 Philip H. Smith
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+*)
+
+Require Import Way.Tactics.
+
+Require Import Way.Beta.
+Require Import Way.Open.
+Require Import Way.Preterm.
+Require Import Way.Relation.
+
+(* The small-step conversion relation.
+
+The calculus of constructions and related theories have a notion of type equivalence: if
+two well-sorted types are "convertible" then the terms of one are the terms of the other.
+Two terms (such as these types) are convertible if they are equal after applying some
+sequence of reduction rules, such as those of beta reduction.
+
+This is "small-step" since it has not yet been extended into an equivalence relation.
+*)
+Inductive step : relation :=
+
+(* Terms are convertible if one beta reduces to the other. *)
+| beta : forall (t u : preterm), Beta.beta t u -> step t u.
+
+Hint Constructors step : way.
+
+Definition conversion := equivalence step.
+
+Hint Unfold conversion : way.
+
+Module Examples.
+
+Import Aliases.
+
+Example conversion_relates_terms_with_common_beta_reducts :
+  conversion
+    (prod
+      (app (abs (type 1) (bvar 0)) (type 0))
+      (type 0))
+    (prod
+      (type 0)
+      (app (abs (type 1) (bvar 0)) (type 0))).
+Proof.
+  apply (Equivalence.transitivity Conversion.step (prod (type 0) (type 0)));
+  [ | apply Equivalence.symmetry ];
+  infer.
+Defined.
+
+End Examples.

--- a/src/Way/FreeVariables.v
+++ b/src/Way/FreeVariables.v
@@ -1,0 +1,78 @@
+(*
+  vim: filetype=coq
+*)
+(*
+Copyright (C) 2016-2017 Philip H. Smith
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+*)
+
+Require Import Way.Tactics.
+
+Require Import Way.Preterm.
+
+(* Collect the names of the free variables in a preterm into a list. *)
+Fixpoint free_variables (p : preterm) : list atom :=
+  match p with
+
+  | free_variable a => [a]
+
+  | bound_variable _ => []
+
+  | product a b => (free_variables a) ++ (free_variables b)
+
+  | abstraction a b => (free_variables a) ++ (free_variables b)
+
+  | application f a => (free_variables f) ++ (free_variables a)
+
+  | type _ => []
+
+  end.
+
+Module Examples.
+
+Import Aliases.
+
+Example free_variables_of_fvar_is_singleton :
+  forall (a : atom), free_variables (fvar a) = [a].
+Proof.
+  infer.
+Defined.
+
+Example free_variables_of_bvar_are_empty : free_variables (bvar 0) = [].
+Proof.
+  infer.
+Defined.
+
+Example free_variables_of_prod_are_those_of_domain_and_codomain :
+  forall (a b : atom), free_variables (prod (fvar a) (fvar b)) = [a; b].
+Proof.
+  infer.
+Defined.
+
+Example free_variables_of_abs_are_those_of_annotation_and_body :
+  forall (a b : atom), free_variables (abs (fvar a) (fvar b)) = [a; b].
+Proof.
+  infer.
+Defined.
+
+Example free_variables_of_app_are_those_of_function_and_argument :
+  forall (a b : atom), free_variables (abs (fvar a) (fvar b)) = [a; b].
+Proof.
+  infer.
+Defined.
+
+Example free_variables_of_type_are_empty : free_variables (type 0) = [].
+Proof.
+  infer.
+Defined.
+
+End Examples.

--- a/src/Way/List.v
+++ b/src/Way/List.v
@@ -50,6 +50,18 @@ Proof.
   infer.
 Defined.
 
+Definition map {A B : Type} (f : A -> B) (l : list A) : list B :=
+  fold (fun e t => (f e) :: t) [] l.
+
+Module MapExamples.
+
+Example successor_over_triple : map S [3; 1; 4] = [4; 2; 5].
+Proof.
+  infer.
+Defined.
+
+End MapExamples.
+
 Definition has {A : Type} (a : A) (l : list A) : Prop :=
   fold (fun e acc => e = a \/ acc) False l.
 

--- a/src/Way/Open.v
+++ b/src/Way/Open.v
@@ -1,0 +1,108 @@
+(*
+  vim: filetype=coq
+*)
+(*
+Copyright (C) 2016-2017 Philip H. Smith
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+*)
+
+Require Import Way.Tactics.
+
+Require Import Way.Nat.
+Require Import Way.Preterm.
+
+(* Replace a bound variable i with replacement u in preterm p
+
+No shifting, lifting or other house keeping is done on the remaining de Bruijn indices.
+*)
+Fixpoint open (i : nat) (u p : preterm) : preterm :=
+  match p with
+
+  | free_variable _ => p
+
+  | bound_variable b => if eq_nat_dec i b then u else p
+
+  | product a b => product (open i u a) (open (S i) u b)
+
+  | abstraction a b => abstraction (open i u a) (open (S i) u b)
+
+  | application f a => application (open i u f) (open i u a)
+
+  | type _ => p
+
+  end.
+
+(* Open bound variable 0 in a term with a free variable. *)
+Definition open_free (a : atom) (p : preterm) : preterm :=
+  open 0 (Preterm.free_variable a) p.
+
+Hint Unfold open_free : way.
+
+Module Examples.
+
+Import Aliases.
+
+Example fvar_is_unchanged :
+  forall (a b : atom), open_free a (fvar b) = (fvar b).
+Proof.
+  infer.
+Defined.
+
+Example same_bvar_is_opened :
+  forall (a : atom), open_free a (bvar 0) = (fvar a).
+Proof.
+  infer.
+Defined.
+
+Example different_bvar_is_unchanged :
+  forall (a : atom), open_free a (bvar 1) = (bvar 1).
+Proof.
+  infer.
+Defined.
+
+Example prod_opens_bvar_into_annotation :
+  forall (a : atom), open_free a (prod (bvar 0) (bvar 0)) = (prod (fvar a) (bvar 0)).
+Proof.
+  infer.
+Defined.
+
+Example prod_opens_incremented_bvar_into_body :
+  forall (a : atom), open_free a (prod (bvar 1) (bvar 1)) = (prod (bvar 1) (fvar a)).
+Proof.
+  infer.
+Defined.
+
+Example abs_opens_bvar_into_annotation :
+  forall (a : atom), open_free a (abs (bvar 0) (bvar 0)) = (abs (fvar a) (bvar 0)).
+Proof.
+  infer.
+Defined.
+
+Example abs_opens_incremented_bvar_into_body :
+  forall (a : atom), open_free a (abs (bvar 1) (bvar 1)) = (abs (bvar 1) (fvar a)).
+Proof.
+  infer.
+Defined.
+
+Example app_opens_into_subterms :
+  forall (a : atom), open_free a (app (bvar 0) (bvar 0)) = (app (fvar a) (fvar a)).
+Proof.
+  infer.
+Defined.
+
+Example type_is_unchanged :
+  forall (a : atom) (n : nat), open_free a (type n) = (type n).
+Proof.
+  infer.
+Defined.
+
+End Examples.

--- a/src/Way/Preterm.v
+++ b/src/Way/Preterm.v
@@ -1,0 +1,89 @@
+(*
+  vim: filetype=coq
+*)
+(*
+Copyright (C) 2016-2017 Philip H. Smith
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+*)
+
+Require Import Way.Tactics.
+
+Require Export Way.Atom.
+
+(* Preterms are terms that may have dangling bound variables.
+
+Variables are managed in the locally nameless style. This means that free and bound
+variables are syntactically distinct.  Free variables are identified by names (atoms),
+while bound variables are given de Bruijn indices.  This eliminates the need for alpha
+conversion, but opens the possibility that bound variable indices may be invalid (that is,
+may refer to abstractions which do not exist).  "Local closure" is the property that all
+such indices are valid.
+*)
+Inductive preterm : Set :=
+
+(* A named variable appearing in the term's context *)
+| free_variable : atom -> preterm
+
+(* A nameless variable (de Bruijn index)
+
+de Bruijn indices appearing in binder annotations (the argument types of lambdas and
+products) do not range over the binder they are included in.  Indices appearing in the
+bodies of those terms do.
+
+Thus the polymorphic identity, informally (forall (x : Set), (fun (y : x), y)) becomes
+(prod (type 0) (abs (bvar 0) (bvar 0))).  Notice how the two occurrences of (bvar 0) refer
+to different bound variables even though they appear within the same abs, due to their
+placement.
+*)
+| bound_variable : nat -> preterm
+
+(* Introduce a dependent product *)
+| product : preterm -> preterm -> preterm
+
+(* Introduce a lambda *)
+| abstraction : preterm -> preterm -> preterm
+
+(* Eliminate an abstraction *)
+| application : preterm -> preterm -> preterm
+
+(* Introduce a sort (type of types)
+
+Non-type terms have types whose type is type 0. The type of type 0 is type 1, and so on.
+This is the "stratified" presentation avoiding Girard's paradox.
+*)
+| type : nat -> preterm.
+
+Module Aliases.
+
+(* It seems these simple rewrites cannot be put into notation scopes. *)
+Notation fvar := free_variable.
+Notation bvar := bound_variable.
+Notation prod := product.
+Notation abs := abstraction.
+Notation app := application.
+Notation type := Preterm.type.
+
+End Aliases.
+
+Module Examples.
+
+Import Aliases.
+
+(* Fudge the annotations; omega isn't typable anyway *)
+Example omega :=
+  (app
+    (abs (type 0) (app (bvar 0) (bvar 0)))
+    (abs (type 0) (app (bvar 0) (bvar 0)))).
+
+Example polymorphic_identity := (prod (type 0) (abs (bvar 0) (bvar 0))).
+
+End Examples.

--- a/src/Way/Relation.v
+++ b/src/Way/Relation.v
@@ -1,0 +1,123 @@
+(*
+  vim: filetype=coq
+*)
+(*
+Copyright (C) 2016-2017 Philip H. Smith
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+*)
+
+Require Import Way.Tactics.
+
+Require Import Way.Preterm.
+
+(* A binary relation over preterms. *)
+Definition relation := preterm -> preterm -> Set.
+
+Module Star.
+
+(* The reflexive-transitive closure of a relation. *)
+Inductive star (r : relation) : relation :=
+
+(* Preterms relate to themselves. *)
+| reflexivity : forall (t : preterm), star r t t
+
+(* Preterms relate if related in the underlying relation *)
+| include : forall (t u : preterm), r t u -> star r t u
+
+(* Preterms relate if they relate to a third common preterm. *)
+(* TODO(phs): Syntax-directed *)
+| transitivity : forall (v t u : preterm), star r t v -> star r v u -> star r t u.
+
+(* Don't need transitivity, which needs a parameter and so will never be inferred. *)
+Hint Resolve reflexivity include : way.
+
+End Star.
+
+Export Star.
+
+Module Equivalence.
+
+(* The reflexive-symmetric-transitive closure of a relation. *)
+Inductive equivalence (r : relation) : relation :=
+
+(* Preterms relate to themselves. *)
+| reflexivity : forall (t : preterm), equivalence r t t
+
+(* Preterms relate if related in the underlying relation *)
+| include : forall (t u : preterm), r t u -> equivalence r t u
+
+(* Preterms relate if they relate to a third common preterm. *)
+(* TODO(phs): Syntax-directed *)
+| symmetry : forall (t u : preterm), equivalence r u t -> equivalence r t u
+
+(* Preterms relate if they relate to a third common preterm. *)
+(* TODO(phs): Syntax-directed *)
+| transitivity :
+  forall (v t u : preterm), equivalence r t v -> equivalence r v u -> equivalence r t u.
+
+(* Don't add symmetry, search can spend its depth on useless pairs of applictions. *)
+(* Don't need transitivity, which needs a parameter and so will never be inferred. *)
+Hint Resolve reflexivity include : way.
+
+End Equivalence.
+
+Export Equivalence.
+
+Module Examples.
+
+Import Aliases.
+
+Inductive example_relation : relation :=
+| decrease : forall (n : nat), example_relation (type (S n)) (type n).
+
+Example star_relations_are_reflexive : star example_relation (type 3) (type 3).
+Proof.
+  infer.
+Defined.
+
+Example star_relations_include_their_arguments : star example_relation (type 1) (type 0).
+Proof.
+  infer from decrease.
+Defined.
+
+Example star_relations_are_transitive : star example_relation (type 2) (type 0).
+Proof.
+  infer from (Star.transitivity example_relation (type 1)) decrease.
+Defined.
+
+Example equivalence_relations_are_reflexive :
+  equivalence example_relation (type 2) (type 2).
+Proof.
+  infer.
+Defined.
+
+Example equivalence_relations_include_their_arguments :
+  equivalence example_relation (type 1) (type 0).
+Proof.
+  infer from decrease.
+Defined.
+
+Example equivalence_relations_are_symmetric :
+  equivalence example_relation (type 0) (type 1).
+Proof.
+  infer from Equivalence.symmetry decrease.
+Defined.
+
+Example equivalence_relations_are_transitive :
+  equivalence example_relation (type 2) (type 0).
+Proof.
+  infer from
+    (Equivalence.transitivity example_relation (type 1))
+    decrease.
+Defined.
+
+End Examples.

--- a/src/Way/Repl.v
+++ b/src/Way/Repl.v
@@ -20,4 +20,16 @@ Require Export Way.Nat.
 Require Export Way.List.
 Require Export Way.ListNat.
 Require Export Way.Atom.
+Require Export Way.Preterm.
+Require Export Way.Context.
+Require Export Way.FreeVariables.
+Require Export Way.StaleAtoms.
+Require Export Way.Relation.
+Require Export Way.Open.
 Require Export Way.Term.
+Require Export Way.Beta.
+Require Export Way.Conversion.
+Require Export Way.Subtyping.
+Require Export Way.Typing.
+
+Export Way.Preterm.Aliases.

--- a/src/Way/StaleAtoms.v
+++ b/src/Way/StaleAtoms.v
@@ -1,0 +1,52 @@
+(*
+  vim: filetype=coq
+*)
+(*
+Copyright (C) 2016-2017 Philip H. Smith
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+*)
+
+Require Import Way.Tactics.
+
+Require Import Way.Context.
+Require Import Way.FreeVariables.
+Require Import Way.List.
+Require Import Way.Preterm.
+
+Ltac stale_atoms :=
+  let rec find acc :=
+    match goal with
+    | l: list atom |- _ => collect acc l
+    | a: atom |- _ => collect acc [a]
+    | c: Context.context |- _ => collect acc (domain c)
+    | p: preterm |- _ => collect acc (free_variables p)
+    | _ => acc
+    end
+  with collect acc l :=
+    match acc with
+    | [] => find l
+    | context [l] => fail 1
+    | _ => find (l ++ acc)
+    end in
+  let rec prettify acc l :=
+    match l with
+    | ?l1 ++ ?l2 => let acc1 := prettify acc l2 in prettify acc1 l1
+    | [] => acc
+    | ?l1 =>
+      match acc with
+      | [] => l1
+      | context [l1] => acc
+      | _ => constr:(l1 ++ acc)
+      end
+    end in
+  let stale := find (@nil atom) in
+  prettify (@nil atom) stale.

--- a/src/Way/Subtyping.v
+++ b/src/Way/Subtyping.v
@@ -1,0 +1,95 @@
+(*
+  vim: filetype=coq
+*)
+(*
+Copyright (C) 2016-2017 Philip H. Smith
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+*)
+
+Require Import Way.Tactics.
+
+Require Import Way.Conversion.
+Require Import Way.Open.
+Require Import Way.Preterm.
+Require Import Way.Relation.
+Require Import Way.Term.
+
+(* The subtyping relation.
+
+Subtyping serves two roles in this logic.  First it includes conversion, and so the
+conversion typing rule becomes the subtyping rule.  Second it brings transitivity to the
+type hierarchy, allowing (type 0) to be considered a term of (type 2), for example.
+*)
+Inductive subtyping : relation :=
+
+(* Convertible types are subtypes of each other. *)
+| conversion : forall (T U : preterm), Conversion.conversion T U -> subtyping T U
+
+(* Each sort is a subtype of the next in the hierarchy. *)
+| type : forall (n : nat), subtyping (Preterm.type n) (Preterm.type (S n))
+
+(* Subtyping descends into codomains of products with convertible domains. *)
+| product : forall (l : list atom) (T V : preterm), Conversion.conversion T V ->
+  forall (U W : preterm), (fresh (a : l), subtyping (open_free a U) (open_free a W)) ->
+  subtyping (Preterm.product T U) (Preterm.product V W)
+
+(* Terms are reflexivily subtypes of themselves. *)
+(* TODO(phs): If we could move this guard then we could use star. *)
+(* TODO(phs): Alternately, we could demand relations deal only in terms *)
+| reflexivity : forall (T : preterm), term T -> subtyping T T
+
+(* Subtyping is transitive. *)
+| transitivity :
+    forall (U T V : preterm), subtyping T U -> subtyping U V -> subtyping T V.
+
+Hint Resolve conversion type reflexivity : way.
+
+Module Examples.
+
+Import Aliases.
+
+Example convertible_terms_are_subtypes :
+  subtyping
+    (app (abs (type 1) (bvar 0)) (type 0))
+    (type 0).
+Proof.
+  infer.
+Defined.
+
+Example sort_is_subtype_of_next : subtyping (type 2) (type 3).
+Proof.
+  infer.
+Defined.
+
+Example subtyping_descends_into_product_codomains :
+  subtyping
+    (prod (type 0) (app (abs (type 1) (bvar 0)) (type 0)))
+    (prod (type 0) (type 0)).
+Proof.
+  infer.
+Defined.
+
+Example subtyping_is_reflexive_for_terms :
+  subtyping
+    (abs (type 0) (bvar 0))
+    (abs (type 0) (bvar 0)).
+Proof.
+  infer.
+Defined.
+
+Example subtyping_is_transitive : subtyping (type 0) (type 2).
+Proof.
+  apply (Subtyping.transitivity (type 1));
+  infer.
+Defined.
+
+End Examples.

--- a/src/Way/Tactics.v
+++ b/src/Way/Tactics.v
@@ -85,17 +85,23 @@ Hint Constructors
 (* A separate hint database for our own hints. *)
 Create HintDb way discriminated.
 
+Hint Unfold
+  notT
+: way.
+
 (* Our central work-horse tactic, in the spirit of Prof. Chlipala's crush. *)
-Hint Extern 5 => simpl in * : way.
+Hint Extern 5 => progress simpl in * : way.
 Hint Extern 5 => match goal with
 | [ |- context[match ?I with _ => _ end] ] => destruct I
 end : way.
 
-Hint Extern 6 => subst : way.
+Hint Extern 6 => progress subst : way.
 Hint Extern 6 => contradiction : way.
-Hint Extern 6 => f_equal : way.
+Hint Extern 6 => progress f_equal : way.
 Hint Extern 6 => congruence : way.
 Hint Extern 6 => progress intuition idtac : way.
+
+(* Level 7 is reserved for application-specific tactics. *)
 
 Hint Extern 8 => match goal with
 | [ H : ex _ |- _ ] => destruct H
@@ -111,6 +117,7 @@ end : way.
 Hint Extern 9 => symmetry : way.
 
 Tactic Notation "infer" "from" constr_list(lemmas) :=
-  auto 5 using lemmas with nocore waycore way.
+  auto 5 using lemmas with nocore waycore way;
+  auto 20 using lemmas with nocore waycore way.
 
 Tactic Notation "infer" := infer from.

--- a/src/Way/Term.v
+++ b/src/Way/Term.v
@@ -15,151 +15,24 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 *)
 
+Require Import Way.StaleAtoms.
 Require Import Way.Tactics.
 
-Require Import Way.List.
-Require Import Way.Nat.
+Require Import Way.Open.
+Require Import Way.Preterm.
 
-Require Export Way.Atom.
+(* A preterm is locally closed if every bound variable refers to some abstraction.
 
-(*
-Preterms are structurally identical to terms, but lack proofs of needed invariants.
-
-The "locally nameless" pattern is used to manage variables.  This means that bound
-variables are given de Bruijn indices instead of names.  This eliminates the need for
-alpha conversion, but opens the possibility that bound variable indices may be invalid
-(that is, may refer to abstractions which do not exist).  "Local closure" is the property
-that all such indices are valid, see below.
-*)
-Inductive preterm : Set :=
-
-(* A named variable in an open term *)
-| free_variable : atom -> preterm
-
-(* A nameless variable (a de Bruijn index over all binders) *)
-| bound_variable : nat -> preterm
-
-(* Introduce a lambda *)
-| abstraction : preterm -> preterm
-
-(* Introduce a dependent product *)
-| product : preterm -> preterm
-
-(* Eliminate an abstraction *)
-| application : preterm -> preterm -> preterm
-
-(* Eliminate a product *)
-| product_application : preterm -> preterm -> preterm
-
-(* The hierarchy of type universes *)
-| type : nat -> preterm.
-
-Module Aliases.
-
-Definition fvar := free_variable.
-Definition bvar := bound_variable.
-Definition abs := abstraction.
-Definition prod := product.
-Definition app := application.
-Definition papp := product_application.
-
-End Aliases.
-
-Module PretermExamples.
-
-Include Aliases.
-
-Example omega :=
-  (app
-    (abs (app (bvar 0) (bvar 0)))
-    (abs (app (bvar 0) (bvar 0)))).
-
-(* It looks strange without its typing annotations, but here it is *)
-Example polymorphic_identity := (prod (abs (bvar 0))).
-
-End PretermExamples.
-
-Module LocalClosure.
-
-(* Replace a bound variable i with replacement u in preterm p *)
-Fixpoint substitute_bound (i : nat) (u p : preterm) : preterm :=
-  match p with
-  | free_variable _ => p
-  | bound_variable b => if eq_nat_dec i b then u else p
-  | abstraction b => (abstraction (substitute_bound (S i) u b))
-  | product b => (product (substitute_bound (S i) u b))
-  | application f a =>
-      application (substitute_bound i u f) (substitute_bound i u a)
-  | product_application f a =>
-      product_application (substitute_bound i u f) (substitute_bound i u a)
-  | type _ => p
-  end.
-
-Module SubstituteBoundExamples.
-
-Include Aliases.
-
-Example fvar_is_unchanged :
-  forall (a b : atom), substitute_bound 0 (fvar a) (fvar b) = (fvar b).
-Proof.
-  infer.
-Defined.
-
-Example bvar_is_substituted :
-  forall (a : atom), substitute_bound 0 (fvar a) (bvar 0) = (fvar a).
-Proof.
-  infer.
-Defined.
-
-Example wrong_bvar_is_unchanged :
-  forall (a : atom), substitute_bound 0 (fvar a) (bvar 1) = (bvar 1).
-Proof.
-  infer.
-Defined.
-
-Example abs_substitutes_incremented_bvar :
-  forall (a : atom), substitute_bound 0 (fvar a) (abs (bvar 1)) = (abs (fvar a)).
-Proof.
-  infer.
-Defined.
-
-Example prod_substitutes_incremented_bvar :
-  forall (a : atom), substitute_bound 0 (fvar a) (prod (bvar 1)) = (prod (fvar a)).
-Proof.
-  infer.
-Defined.
-
-Example app_substitutes_into_subterms :
-  forall (a : atom), substitute_bound 0 (fvar a)
-    (app (bvar 0) (bvar 0)) = (app (fvar a) (fvar a)).
-Proof.
-  infer.
-Defined.
-
-Example papp_substitutes_into_subterms :
-  forall (a : atom), substitute_bound 0 (fvar a)
-    (papp (bvar 0) (bvar 0)) = (papp (fvar a) (fvar a)).
-Proof.
-  infer.
-Defined.
-
-Example type_is_unchanged :
-  forall (a : atom) (n : nat), substitute_bound 0 (fvar a) (type n) = (type n).
-Proof.
-  infer.
-Defined.
-
-End SubstituteBoundExamples.
-
-(*
-A preterm is locally closed if every bound variable refers to some abstraction.
+Local closure is the only criterion needed to establish a preterm as a term, so the type
+here is named "term".
 
 A proof of local closure reflects the shape of its preterm, with two key differences.
 
 First, we transform abstraction bodies before demanding local closure of the result.  The
-transformation is to substitute a "sufficiently fresh" free variable for the new bound
-variable. This bound variable will therefore not appear in the preterm of the required
-subproof.
+transformation is to open a "sufficiently fresh" free variable for the new bound variable.
+This bound variable will therefore not appear in the preterm of the required subproof.
+Since abstraction annotations should not refer to the new abstraction variable, no
+substitution is performed on them.
 
 Second, there is no local closure constructor for bound variables.
 
@@ -167,136 +40,102 @@ If all bound variables properly refer to some abstraction, then by the first poi
 will all be replaced by free variables by the time we consider the proof of their local
 closure.  Any bound variables that remain must be dangling.
 
-By the second point, preterms with such bound variables will be unable to prove local
-closure, due to the lack of a suitable constructor.  On the other hand, preterms without
-dangling bound variables will have no need of one.
+By the second point, preterms with dangling bound variables will be unable to prove local
+closure, due to the lack of a suitable constructor.  Preterms without dangling bound
+variables will have no need of one.
 
 "Sufficiently fresh" means exclusion from an arbitrary list of free variables, but think
 "free variables of the abstraction body".  Leaving it unspecified here makes proofs
 somewhat easier later, per the "cofinite induction" pattern.
 *)
-Inductive locally_closed : preterm -> Type :=
+Inductive term : preterm -> Set :=
 
-| free_variable : forall (a : atom), locally_closed (free_variable a)
+| free_variable : forall (a : atom), term (free_variable a)
 
-| abstraction : forall (stale : list atom) (b : preterm),
-  (forall (a : atom), ~ has a stale ->
-    locally_closed (substitute_bound 0 (free_variable a) b)) ->
-  locally_closed (abstraction b)
+| product :
+  forall (l : list atom) (p q : preterm), term p ->
+  (fresh (a : l), term (open_free a q)) ->
+  term (product p q)
 
-| product : forall (stale : list atom) (b : preterm),
-  (forall (a : atom), ~ has a stale ->
-    locally_closed (substitute_bound 0 (free_variable a) b)) ->
-  locally_closed (product b)
+| abstraction :
+  forall (l : list atom) (p q : preterm), term p ->
+  (fresh (a : l), term (open_free a q)) ->
+  term (abstraction p q)
 
-| application : forall (p q : preterm), locally_closed p -> locally_closed q ->
-  locally_closed (application p q)
+| application : forall (p q : preterm), term p -> term q -> term (application p q)
 
-| product_application : forall (p q : preterm), locally_closed p -> locally_closed q ->
-  locally_closed (product_application p q)
+| type : forall (n : nat), term (type n).
 
-| type : forall (n : nat), locally_closed (type n).
+Hint Resolve free_variable application type : way.
+
+Hint Extern 7 (term (Preterm.product _ _)) =>
+  let stale := stale_atoms in apply (Term.product stale) : way.
+
+Hint Extern 7 (term (Preterm.abstraction _ _)) =>
+  let stale := stale_atoms in apply (Term.abstraction stale) : way.
 
 Module Examples.
 
-Include Aliases.
+Import Aliases.
 
-Example omega :
-  locally_closed (app (abs (app (bvar 0) (bvar 0))) (abs (app (bvar 0) (bvar 0)))).
+Example omega : term Preterm.Examples.omega.
 Proof.
-  (* TODO(phs): infer search depth/order *)
-  apply application;
-  infer from application (abstraction []) free_variable.
+  unfold Preterm.Examples.omega; infer.
 Defined.
 
-Example polymorphic_identity : locally_closed (prod (abs (bvar 0))).
+Example polymorphic_identity : term (prod (type 0) (abs (bvar 0) (bvar 0))).
 Proof.
-  (* TODO(phs): infer search depth/order *)
-  apply (product []);
-  intros; simpl; destruct (eq_nat_dec 1 0); try congruence;
-  infer from (product []) (abstraction []) free_variable.
+  infer.
 Defined.
 
-Example fvar_is_locally_closed : forall (a : atom), locally_closed (fvar a).
+Example fvar_is_term : forall (a : atom), term (fvar a).
 Proof.
-  apply free_variable.
+  infer.
 Defined.
 
-Example abs_can_be_locally_closed : locally_closed (abs (bvar 0)).
+Example prod_can_be_term : term (prod (type 0) (bvar 0)).
 Proof.
-  infer from (abstraction []) free_variable.
+  infer.
 Defined.
 
-Example abs_can_be_not_locally_closed : notT (locally_closed (abs (bvar 1))).
+Example prod_can_be_not_term : notT (term (prod (type 0) (bvar 1))).
 Proof.
   intro H;
-  inversion H as [ | stale ? CFH | | | | ];
+  inversion H as [ | stale ? ? ? CFH | | | ];
   subst;
   destruct (fresh_atom stale) as [a Hfresh];
   pose proof (CFH a Hfresh) as Himpossible;
   infer.
 Defined.
 
-Example prod_can_be_locally_closed : locally_closed (prod (bvar 0)).
+Example abs_can_be_term : term (abs (type 0) (bvar 0)).
 Proof.
-  infer from (product []) free_variable.
+  infer.
 Defined.
 
-Example prod_can_be_not_locally_closed : notT (locally_closed (prod (bvar 1))).
+Example abs_can_be_not_term : notT (term (abs (type 0) (bvar 1))).
 Proof.
   intro H;
-  inversion H as [ | | stale ? CFH | | | ];
+  inversion H as [ | | stale ? ? ? CFH | | ];
   subst;
   destruct (fresh_atom stale) as [a Hfresh];
   pose proof (CFH a Hfresh) as Himpossible;
   infer.
 Defined.
 
-Example app_can_be_locally_closed :
-  forall (a : atom), locally_closed (app (fvar a) (fvar a)).
+Example app_can_be_term : forall (a : atom), term (app (fvar a) (fvar a)).
 Proof.
-  infer from application free_variable.
+  infer.
 Defined.
 
-Example app_can_be_not_locally_closed : notT (locally_closed (app (bvar 0) (bvar 0))).
+Example app_can_be_not_term : notT (term (app (bvar 0) (bvar 0))).
 Proof.
-  (* TODO(phs): Explicit unfold should be unnecessary. *)
-  unfold notT;
-  infer from application.
+  infer.
 Defined.
 
-Example papp_can_be_locally_closed :
-  forall (a : atom), locally_closed (papp (fvar a) (fvar a)).
+Example type_is_term : term (type 0).
 Proof.
-  infer from product_application free_variable.
+  infer.
 Defined.
-
-Example papp_can_be_not_locally_closed : notT (locally_closed (papp (bvar 0) (bvar 0))).
-Proof.
-  (* TODO(phs): Explicit unfold should be unnecessary. *)
-  unfold notT;
-  infer from product_application.
-Defined.
-
-Example type_is_locally_closed : locally_closed (Term.type 0).
-Proof.
-  infer from type.
-Defined.
-
-End Examples.
-
-End LocalClosure.
-
-Definition locally_closed := LocalClosure.locally_closed.
-
-(* A term is a locally closed preterm. *)
-Definition term := { p : preterm & locally_closed p }.
-
-Module Examples.
-
-Definition preterm_omega := PretermExamples.omega.
-Definition omega_locally_closed := LocalClosure.Examples.omega.
-
-Example omega : term := existT locally_closed preterm_omega omega_locally_closed.
 
 End Examples.

--- a/src/Way/Typing.v
+++ b/src/Way/Typing.v
@@ -1,0 +1,184 @@
+(*
+  vim: filetype=coq
+*)
+(*
+Copyright (C) 2016-2017 Philip H. Smith
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+*)
+
+Require Import Way.StaleAtoms.
+Require Import Way.Tactics.
+
+Require Import Way.Beta.
+Require Import Way.Context.
+Require Import Way.Conversion.
+Require Import Way.Open.
+Require Import Way.Preterm.
+Require Import Way.Relation.
+Require Import Way.Subtyping.
+
+(* Typings are proofs that under a given context, a given term has the given type.
+
+Since types are terms, this emerges as a ternary relation between a context and two terms.
+
+An interesting twist appears in the definition of contexts.  A context is a list that that
+identifies the types of free variables in a term.  Since types are terms, the types
+appearing in the context must themselves be well-typed, and can have free variables.  This
+circular dependency is accounted for with a pair of mutually recursive definitions (or
+"judgements").
+
+The first kind of judgement is the typing of terms.
+*)
+Inductive typing : context -> preterm -> preterm -> Set :=
+
+(* The type of a sort is the next sort in the hierarchy. *)
+| type :
+  forall (c : context), well_formed c -> forall (n : nat),
+  typing c (Preterm.type n) (Preterm.type (S n))
+
+(* The type of a free variable is that which it is bound to in a well-formed context. *)
+| free_variable :
+  forall (c : context), well_formed c -> forall (a : atom) (T : preterm), has (a, T) c ->
+  typing c (Preterm.free_variable a) T
+
+(* The type of a product is a sort, shared with its domain and codomain after opening.
+
+Since the codomain can depend on the domain, we only require it to type after opening it
+with the domain (using a sufficiently fresh free variable.)
+*)
+| product :
+  forall (l : list atom) (c : context) (n : nat) (T U : preterm),
+  typing c T (Preterm.type n) ->
+  (fresh (a : l), typing ((a, T) :: c) (open_free a U) (Preterm.type n)) ->
+  typing c (Preterm.product T U) (Preterm.type n)
+
+(* The type of an abstraction is a well-typed product.
+
+The abstraction body must have the product codomain as its type, after each has been
+opened with the product's domain type (using a sufficiently fresh free variable.)
+*)
+| abstraction :
+  forall (l : list atom) (n : nat) (c : context) (T U : preterm),
+  typing c (Preterm.product T U) (Preterm.type n) ->
+  forall (t : preterm),
+  (fresh (a : l), typing ((a, T) :: c) (open_free a t) (open_free a U)) ->
+  typing c (Preterm.abstraction T t) (Preterm.product T U)
+
+(* The type of an application is its abstraction's codomain type opened with the argument.
+
+The abstraction must have a product as its type, and the argument must be well-typed.
+The equation involving open is required to allow proof search to match the head.
+*)
+| application :
+  forall (T U : preterm) (c : context) (u : preterm),
+  typing c u (Preterm.product T U) ->
+  forall (t : preterm), typing c t T ->
+  forall (v : preterm), v = open 0 t U ->
+  typing c (Preterm.application u t) v
+
+| subtyping :
+  forall (T : preterm) (n : nat) (U : preterm), Subtyping.subtyping T U ->
+  forall (c : context) (t : preterm), typing c t T ->
+  typing c U (Preterm.type n) ->
+  typing c t U
+
+(* The second kind of judgement is the well-formation of contexts. *)
+with well_formed : context -> Set :=
+
+(* Empty contexts are well-formed. *)
+| empty : well_formed []
+
+(* A context that types a term as a type can be extended by it with a fresh variable. *)
+| extend :
+  forall (n : nat) (c : context) (T : preterm), typing c T (Preterm.type n) ->
+  fresh (a : (domain c)), well_formed ((a, T) :: c).
+
+Hint Resolve type free_variable empty : way.
+
+Hint Extern 7 (typing _ (Preterm.product _ _) (Preterm.type _)) =>
+  let stale := stale_atoms in apply (Typing.product stale) : way.
+
+(* TODO(phs): hint extern for abstraction application subtyping extend *)
+
+Module Examples.
+
+Import Aliases.
+
+(* TODO(phs): Demonstrate polymorphic identity application *)
+(* You chose type 0 in the definition of the identity.  This is tricky without base types
+or the polymorphism allowing us to elide universe indices.
+Example polymorphic_identity :
+  typing []
+    (app Preterm.Example.polymorphic_identity (abs (type 0) (bvar 0)))
+    (prod (type 0) (type 0))
+*)
+
+Example type_of_sort_is_next_sort : typing [] (type 3) (type 4).
+Proof.
+  infer.
+Defined.
+
+Example type_of_free_variable_is_in_context :
+  forall (a : atom), typing [(a, (type 7))] (fvar a) (type 7).
+Proof.
+  infer from (Typing.extend 8).
+Defined.
+
+Example type_of_product_is_sort : typing [] (prod (type 1) (type 1)) (type 2).
+Proof.
+  infer from (Typing.extend 2).
+Defined.
+
+Example type_of_abstraction_is_product :
+  typing [] (abs (type 3) (bvar 0)) (prod (type 3) (type 3)).
+Proof.
+  infer from
+    (Typing.abstraction [] 4)
+    (Typing.extend 4).
+Defined.
+
+Example type_of_application_is_product_codomain :
+  typing [] (app (abs (type 1) (bvar 0)) (type 0)) (type 1).
+Proof.
+  infer from
+    (Typing.application (type 1) (type 1))
+    (Typing.abstraction [] 2)
+    (Typing.extend 2).
+Defined.
+
+Example terms_of_subtype_are_terms_of_supertype :
+  typing []
+    (type 0)
+    (app (abs (type 2) (bvar 0)) (type 1)).
+Proof.
+  apply (Typing.subtyping (type 1) 2);
+  [ apply Subtyping.conversion;
+    apply Equivalence.symmetry
+  | | ];
+  infer from
+    (Typing.application (type 2) (type 2))
+    (Typing.abstraction [] 3)
+    (Typing.extend 3).
+Defined.
+
+Example empty_context_is_well_formed : well_formed [].
+Proof.
+  infer.
+Defined.
+
+Example context_extended_with_fresh_name_is_well_formed :
+  forall (a b : atom), a <> b -> well_formed [(a, (type 0)); (b, (type 0))].
+Proof.
+  infer from (Typing.extend 1).
+Defined.
+
+End Examples.


### PR DESCRIPTION
Some points to note:

* The "cofinite induction" style is used, using `fresh` to ease declarations
* `product_application` is dropped, apparently I simply made it up
* We are still predicative for now, so we're not strictly CoC.
* `substitute_bound` has become `open`
* `locally_closed` has become `term`
* `sort` has become `type`
* `progress` is used more in `infer`, more aggressively pruning search
* `infer` now proceeds in two passes, first shallowly and then deeply.  In the absence of
  breadth-first search, this seems to strike a good balance between speed and
  expressiveness.
* Inductive constructors are added as hints.  It is clear that they are so commonly (and
  numerously) needed in even simple examples that there is no enlightenment to be had by
  enumerating them on use.  Un-inferrable parameters (which `auto` refuses to introduce as
  existential goals anyway) are still passed explicitly.
* The `stale_atoms` tactic calculates suitable lists of atoms for cofinite quantification.
* `Way.v` has become `Way/Repl.v`, and now exports `Aliases`.

closes #28 