### PR TITLE
Polymorphic identity is an abstraction

### DIFF
--- a/src/Way/Preterm.v
+++ b/src/Way/Preterm.v
@@ -39,8 +39,8 @@ de Bruijn indices appearing in binder annotations (the argument types of lambdas
 products) do not range over the binder they are included in.  Indices appearing in the
 bodies of those terms do.
 
-Thus the polymorphic identity, informally (forall (x : Set), (fun (y : x), y)) becomes
-(prod (type 0) (abs (bvar 0) (bvar 0))).  Notice how the two occurrences of (bvar 0) refer
+Thus the polymorphic identity, informally (fun (x : Set) (y : x) => y) becomes
+(abs (type 0) (abs (bvar 0) (bvar 0))).  Notice how the two occurrences of (bvar 0) refer
 to different bound variables even though they appear within the same abs, due to their
 placement.
 *)
@@ -84,6 +84,6 @@ Example omega :=
     (abs (type 0) (app (bvar 0) (bvar 0)))
     (abs (type 0) (app (bvar 0) (bvar 0)))).
 
-Example polymorphic_identity := (prod (type 0) (abs (bvar 0) (bvar 0))).
+Example polymorphic_identity := (abs (type 0) (abs (bvar 0) (bvar 0))).
 
 End Examples.

--- a/src/Way/Term.v
+++ b/src/Way/Term.v
@@ -83,9 +83,9 @@ Proof.
   unfold Preterm.Examples.omega; infer.
 Defined.
 
-Example polymorphic_identity : term (prod (type 0) (abs (bvar 0) (bvar 0))).
+Example polymorphic_identity : term Preterm.Examples.polymorphic_identity.
 Proof.
-  infer.
+  unfold Preterm.Examples.polymorphic_identity; infer.
 Defined.
 
 Example fvar_is_term : forall (a : atom), term (fvar a).

--- a/src/Way/Typing.v
+++ b/src/Way/Typing.v
@@ -113,12 +113,77 @@ Module Examples.
 
 Import Aliases.
 
+(* TODO(phs): Use the type checker once it exists *)
+Example polymorphic_identity :
+  typing []
+    Preterm.Examples.polymorphic_identity
+    (prod (type 0) (prod (bvar 0) (bvar 1))).
+Proof.
+  unfold Preterm.Examples.polymorphic_identity;
+  apply (Typing.abstraction [] 1);
+  [ apply (Typing.product []);
+    [ infer
+    | intros a Ha; unfold open_free;
+      apply (Typing.subtyping (type 1) 2);
+      [ infer
+      | apply (Typing.product [a]);
+        [ apply (Typing.subtyping (type 0) 2);
+          infer from (Typing.extend 1)
+        | intros b Hb; unfold open_free;
+          apply (Typing.subtyping (type 0) 2);
+          [ infer
+          | apply Typing.free_variable;
+            [ apply (Typing.extend 0);
+              [ apply Typing.free_variable;
+                infer from (Typing.extend 1)
+              | infer
+              ]
+            | infer
+            ]
+          | apply Typing.type;
+            apply (Typing.extend 0);
+            [ apply Typing.free_variable;
+              infer from (Typing.extend 1)
+            | infer
+            ]
+          ]
+        ]
+      | infer from (Typing.extend 1)
+      ]
+    ]
+  | intros a Ha; unfold open_free;
+    apply (Typing.abstraction [a] 0);
+    [ apply (Typing.product [a]);
+      [ infer from (Typing.extend 1)
+      | intros b Hb; unfold open_free;
+        apply Typing.free_variable;
+        [ apply (Typing.extend 0);
+          [ apply Typing.free_variable;
+            infer from (Typing.extend 1)
+          | infer
+          ]
+        | infer
+        ]
+      ]
+    | intros b Hb; unfold open_free;
+      apply Typing.free_variable;
+      [ apply (Typing.extend 0);
+        [ apply Typing.free_variable;
+          infer from (Typing.extend 1)
+        | infer
+        ]
+      | infer
+      ]
+    ]
+  ].
+Defined.
+
 (* TODO(phs): Demonstrate polymorphic identity application *)
 (* You chose type 0 in the definition of the identity.  This is tricky without base types
 or the polymorphism allowing us to elide universe indices.
-Example polymorphic_identity :
+Example apply_polymorphic_identity :
   typing []
-    (app Preterm.Example.polymorphic_identity (abs (type 0) (bvar 0)))
+    (app Preterm.Examples.polymorphic_identity (abs (type 0) (bvar 0)))
     (prod (type 0) (type 0))
 *)
 


### PR DESCRIPTION
While we're at it, demonstrate typing by exhibiting the derivation.  It's a big gross manual proof; I want to get this correction in before coding up an explicit type checker.